### PR TITLE
Slight changes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -78,8 +78,18 @@ table.voice {
   border-style: solid;
   border-radius: 0px;
   border-width: 0px;
-  border-color: black;
   font-size: 10pt;
+}
+
+table.repeat {
+  margin: 0px;
+  padding: 0px;
+  display: inline-block;
+  border-style: solid;
+  border-radius: 0px;
+  border-width: 0px;
+  border-color: black;
+  font-size: 9pt;
 }
 
 
@@ -107,11 +117,11 @@ td {
 }*/
 
 
-svg.harp-button-0 .unhighlighted.instrument-button-icon,
-svg.harp-button-1 .unhighlighted.instrument-button-icon,
-svg.harp-button-2 .unhighlighted.instrument-button-icon,
-svg.harp-button-3 .unhighlighted.instrument-button-icon,
-svg.harp-button-4 .unhighlighted.instrument-button-icon {
+.harp-button-0 .unhighlighted.instrument-button-icon,
+.harp-button-1 .unhighlighted.instrument-button-icon,
+.harp-button-2 .unhighlighted.instrument-button-icon,
+.harp-button-3 .unhighlighted.instrument-button-icon,
+.harp-button-4 .unhighlighted.instrument-button-icon {
   stroke-width: 3;
   stroke: white;
   fill: limegreen;
@@ -119,11 +129,11 @@ svg.harp-button-4 .unhighlighted.instrument-button-icon {
 }
 
 
-svg.harp-button-5 .unhighlighted.instrument-button-icon,
-svg.harp-button-6 .unhighlighted.instrument-button-icon,
-svg.harp-button-7 .unhighlighted.instrument-button-icon,
-svg.harp-button-8 .unhighlighted.instrument-button-icon,
-svg.harp-button-9 .unhighlighted.instrument-button-icon {
+.harp-button-5 .unhighlighted.instrument-button-icon,
+.harp-button-6 .unhighlighted.instrument-button-icon,
+.harp-button-7 .unhighlighted.instrument-button-icon,
+.harp-button-8 .unhighlighted.instrument-button-icon,
+.harp-button-9 .unhighlighted.instrument-button-icon {
   stroke-width: 3;
   stroke: white;
   fill: deepskyblue;
@@ -131,11 +141,11 @@ svg.harp-button-9 .unhighlighted.instrument-button-icon {
 }
 
 
-svg.harp-button-10 .unhighlighted.instrument-button-icon,
-svg.harp-button-11 .unhighlighted.instrument-button-icon,
-svg.harp-button-12 .unhighlighted.instrument-button-icon,
-svg.harp-button-13 .unhighlighted.instrument-button-icon,
-svg.harp-button-14 .unhighlighted.instrument-button-icon {
+.harp-button-10 .unhighlighted.instrument-button-icon,
+.harp-button-11 .unhighlighted.instrument-button-icon,
+.harp-button-12 .unhighlighted.instrument-button-icon,
+.harp-button-13 .unhighlighted.instrument-button-icon,
+.harp-button-14 .unhighlighted.instrument-button-icon {
   stroke-width: 3;
   stroke: white;
   fill: deeppink;

--- a/css/main.css
+++ b/css/main.css
@@ -117,11 +117,11 @@ td {
 }*/
 
 
-.harp-button-0 .unhighlighted.instrument-button-icon,
-.harp-button-1 .unhighlighted.instrument-button-icon,
-.harp-button-2 .unhighlighted.instrument-button-icon,
-.harp-button-3 .unhighlighted.instrument-button-icon,
-.harp-button-4 .unhighlighted.instrument-button-icon {
+svg.harp-button-0 .unhighlighted.instrument-button-icon,
+svg.harp-button-1 .unhighlighted.instrument-button-icon,
+svg.harp-button-2 .unhighlighted.instrument-button-icon,
+svg.harp-button-3 .unhighlighted.instrument-button-icon,
+svg.harp-button-4 .unhighlighted.instrument-button-icon {
   stroke-width: 3;
   stroke: white;
   fill: limegreen;
@@ -129,11 +129,11 @@ td {
 }
 
 
-.harp-button-5 .unhighlighted.instrument-button-icon,
-.harp-button-6 .unhighlighted.instrument-button-icon,
-.harp-button-7 .unhighlighted.instrument-button-icon,
-.harp-button-8 .unhighlighted.instrument-button-icon,
-.harp-button-9 .unhighlighted.instrument-button-icon {
+svg.harp-button-5 .unhighlighted.instrument-button-icon,
+svg.harp-button-6 .unhighlighted.instrument-button-icon,
+svg.harp-button-7 .unhighlighted.instrument-button-icon,
+svg.harp-button-8 .unhighlighted.instrument-button-icon,
+svg.harp-button-9 .unhighlighted.instrument-button-icon {
   stroke-width: 3;
   stroke: white;
   fill: deepskyblue;
@@ -141,11 +141,11 @@ td {
 }
 
 
-.harp-button-10 .unhighlighted.instrument-button-icon,
-.harp-button-11 .unhighlighted.instrument-button-icon,
-.harp-button-12 .unhighlighted.instrument-button-icon,
-.harp-button-13 .unhighlighted.instrument-button-icon,
-.harp-button-14 .unhighlighted.instrument-button-icon {
+svg.harp-button-10 .unhighlighted.instrument-button-icon,
+svg.harp-button-11 .unhighlighted.instrument-button-icon,
+svg.harp-button-12 .unhighlighted.instrument-button-icon,
+svg.harp-button-13 .unhighlighted.instrument-button-icon,
+svg.harp-button-14 .unhighlighted.instrument-button-icon {
   stroke-width: 3;
   stroke: white;
   fill: deeppink;

--- a/python/instruments.py
+++ b/python/instruments.py
@@ -9,19 +9,20 @@ class Voice: # Lyrics or comments
     def __init__(self):
         self.instrument_type = 'voice'
         self.chord_skygrid = {}
+        self.repeat = 0
         
-    def render_in_html(self, chord_skygrid, note_width, instrument_index):     
+    def render_in_html(self, lyrics, note_width, instrument_index):     
         chord_render = '<table class=\"voice\">'
         chord_render +='<tr>'
         chord_render +='<td  width=\"90em\" align=\"center\">' #TODO: width calculated automatically
-        chord_render += chord_skygrid
+        chord_render += lyrics
         chord_render += '</td>'
         chord_render +='</tr>'
         chord_render +='</table>'
         return chord_render
 
-    def render_in_ascii(self, chord_skygrid, render_mode):     
-        chord_render = '# ' + chord_skygrid # Lyrics marked as comments in output text files
+    def render_in_ascii(self, lyrics, render_mode):     
+        chord_render = '# ' + lyrics # Lyrics marked as comments in output text files
         return chord_render
     
     def set_chord_skygrid(self, chord_skygrid):
@@ -32,6 +33,12 @@ class Voice: # Lyrics or comments
     
     def get_chord_skygrid(self):
         return self.chord_skygrid
+    
+    def set_repeat(self, repeat):
+        self.repeat = repeat
+
+    def get_repeat(self):
+        return self.repeat
 
 class Harp:
 
@@ -43,6 +50,7 @@ class Harp:
         self.highlighted_states_skygrid = []
         self.instrument_type = 'harp'
         self.is_highlighted = False
+        self.repeat = 0
 
         self.sky_inverse_position_map = {
                 (0, 0): 'A1', (0, 1): 'A2', (0, 2): 'A3', (0, 3): 'A4', (0, 4): 'A5',
@@ -73,6 +81,12 @@ class Harp:
     
     def get_is_highlighted(self):
         return self.is_highlighted
+
+    def set_repeat(self, repeat):
+        self.repeat = repeat
+
+    def get_repeat(self):
+        return self.repeat
 
     def set_is_highlighted(self, is_highlighted):
         '''
@@ -172,5 +186,15 @@ class Harp:
             harp_render += '</tr>'
 
         harp_render += '</table>'
+        
+        if self.get_repeat() > 0:
+            harp_render += '<table class=\"repeat harp-' + str(instrument_index) + ' empty \">'
+            harp_render += '<tr>'
+            harp_render += '<td>'
+            harp_render += 'x' + str(self.get_repeat())       
+            harp_render += '</td>'
+            harp_render += '</tr>'
+            harp_render += '</table>'
+        
         return harp_render
     

--- a/python/main.py
+++ b/python/main.py
@@ -12,11 +12,12 @@ class Error(Exception):
 class BlackIconError(Error):
     pass
 
-QUAVER_DELIMITER = '-' # Hyphen separated list of chords
-ICON_DELIMITER = ' '
-NOTE_WIDTH = "1em"
+# Parameters that can be changed by advanced users
+QUAVER_DELIMITER = '^' # Dash-separated list of chords
+ICON_DELIMITER = ' ' # Chords separation
+NOTE_WIDTH = "1.0em" #Any CSS-compatible unit can be used
 BLANK_ICON = '.'
-COMMENT_DELIMITER = '#'
+COMMENT_DELIMITER = '#' # Lyrics delimiter, can be used for comments
 
 myparser = Parser() # Create a parser object
 
@@ -73,14 +74,14 @@ else:
 
 if song_input_mode in [InputMode.WESTERN, InputMode.WESTERNFILE, InputMode.JIANPU, InputMode.JIANPUFILE]:
     try:
-        octave_shift = int(input('Octave shift (-3 -2 -1 0 1 2 3): ').strip())
+        note_shift = int(input('Shift by n notes (-21 ; +21): ').strip())
     except ValueError:
-        octave_shift = 0
-    else:
-        octave_shift = 0
+        note_shift = 0
+else:
+    note_shift = 0
 
 if song_input_mode in [InputMode.JIANPU, InputMode.JIANPUFILE] and QUAVER_DELIMITER =='-':
-    print('Warning: quaver delimiter \'-\' is incompatible with Jianpu notation. Swtchin to \'^\' instead.')
+    print('\nWarning: quaver delimiter \'-\' is incompatible with Jianpu notation. Please use \'^\' instead.')
     QUAVER_DELIMITER = '^'
 
 print('\nSeparate blocks of notes with \"' + ICON_DELIMITER + '\".')
@@ -122,7 +123,7 @@ if song_input_mode in [InputMode.SKYFILE, InputMode.WESTERNFILE, InputMode.JIANP
     try:
         song_lines = open(fp,mode='r')            
         for song_line in song_lines:
-            instrument_line = myparser.parse_line(song_line.rstrip(), ICON_DELIMITER, BLANK_ICON, QUAVER_DELIMITER, COMMENT_DELIMITER, song_input_mode, octave_shift)            
+            instrument_line = myparser.parse_line(song_line.rstrip(), ICON_DELIMITER, BLANK_ICON, QUAVER_DELIMITER, COMMENT_DELIMITER, song_input_mode, note_shift)            
             instrument_lines.append(instrument_line)    
         song_lines.close()
     except (OSError, IOError) as err:
@@ -130,7 +131,7 @@ if song_input_mode in [InputMode.SKYFILE, InputMode.WESTERNFILE, InputMode.JIANP
         raise err
 else:
     for song_line in song_lines:
-        instrument_line = myparser.parse_line(song_line, ICON_DELIMITER, BLANK_ICON, QUAVER_DELIMITER, COMMENT_DELIMITER, song_input_mode, octave_shift)    
+        instrument_line = myparser.parse_line(song_line, ICON_DELIMITER, BLANK_ICON, QUAVER_DELIMITER, COMMENT_DELIMITER, song_input_mode, note_shift)    
         instrument_lines.append(instrument_line)   
 
 
@@ -148,7 +149,7 @@ original_artists = input('Original artist(s): ')
 transcript_writer = input('Transcribed by: ')
 
 # Renders the song
-titlehead = [['Song title:', song_title]]
+titlehead = [[''], [song_title]]
 headers = [['Original Artist(s):', 'Transcript:', 'Recommended key:'], [original_artists, transcript_writer, musical_key]]
 
 html_path = os.path.join(song_title + '.html')


### PR DESCRIPTION
* Added support for parsing note repetition coded as 'xN' => a xN text is appended to the chord image in the HTML output => this functionnality is not advertised yet in the prompt
* Changed the shift (transposition) from full octave to individual note shift. So the user must now enter +7 or -7 to shift an entire octave. + corrected a bug where note_shift was undefined
* Changed the way of splitting notes in chords with Western notation. Instead of assuming that notes are always 2 char-long, I split before the note uppercase name. => adds support for sharps and flats + note repetition (xN)

PS: it seems that I don't have write access to the beta branch of the main project.
It is fine with me, but this requires Tracey to acknowledge my pull requests.

PPS: Alexdolly gave me permission to use SVG + a package to convert to JPG. So maybe I will first try to output a SVG and using pyCairo for conversion.